### PR TITLE
update to ghc 9.6

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1536926ef5621b09bba54035ae2bb6d806d72ac8",
-        "sha256": "1nwmy7j4nd9ilgvlaqddrrmmzzpmid4zns2yzbqs9ri4xsn80bkk",
+        "rev": "44d0940ea560dee511026a53f0e2e2cde489b4d4",
+        "sha256": "0xxbzvrr7kylvjn2yj0nnrm1qndx8rq99mlkk0ghvy364y5c5pv0",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/1536926ef5621b09bba54035ae2bb6d806d72ac8.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/44d0940ea560dee511026a53f0e2e2cde489b4d4.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "olderIdeaNixpkgs": {

--- a/src/generator/gen-album.hs
+++ b/src/generator/gen-album.hs
@@ -14,7 +14,6 @@ import Codec.Picture (DynamicImage (ImageRGBF), PixelRGBF, convertRGB8, dynamicM
 import Codec.Picture.Metadata
 import qualified Codec.Picture.Types
 import qualified Codec.Picture.Types as M
-import Control.Applicative
 import Control.Concurrent.Async
 import Control.Monad
 import Control.Parallel.Strategies


### PR DESCRIPTION
* niv update

* gen-album.hs: remove Control.Applicative import.  this was added to Prelude in 9.6

* changes to nix-build output:

>>> new
Version changes:
[U.]    libffi  3.4.4 -> 3.4.6
Added packages:
[A.]    brotli             1.1.0-lib
[A.]    bzip2              1.0.8
[A.]    curl               8.6.0
[A.]    elfutils           0.190
[A.]    keyutils           1.6.3-lib
[A.]    libkrb5            1.21.2
[A.]    libpsl             0.21.5
[A.]    libssh2            1.11.0
[A.]    nghttp2            1.60.0-lib
[A.]    openssl            3.0.13
[A.]    publicsuffix-list  0-unstable-2024-01-07
[A.]    xz                 5.6.1
[A.]    zstd               1.5.5
Closure size: 13 -> 26 (26 paths added, 13 paths removed, delta +13, disk usage +17.9MiB).

* changes to nix-shell output:

>>> shell-new
Version changes:
[U.]    aeson-pretty                        0.8.9, 0.8.9-doc -> 0.8.10, 0.8.10-doc
[U.]    ansi-terminal                       0.11.5, 0.11.5-doc -> 1.0.2, 1.0.2-doc
[U.]    ansi-wl-pprint                      0.6.9, 0.6.9-doc -> 1.0.2, 1.0.2-doc
[C.]    at-spi2-core                        2.44.0, 2.50.0 -> 2.44.0, 2.50.1
[U.]    base-compat                         0.12.3, 0.12.3-doc -> 0.13.1, 0.13.1-doc
[U.]    base-compat-batteries               0.12.3, 0.12.3-doc -> 0.13.1, 0.13.1-doc
[U.]    bifunctors                          5.5.15, 5.5.15-doc -> 5.6.1, 5.6.1-doc
[U.]    binutils                            2.40, 2.40-lib -> 2.41, 2.41-lib
[U.]    binutils-wrapper                    2.40 -> 2.41
[U.]    commutative-semigroups              0.1.0.1, 0.1.0.1-doc -> 0.1.0.2, 0.1.0.2-doc
[U.]    constraints                         0.13.4, 0.13.4-doc -> 0.14, 0.14-doc
[U.]    direct-sqlite                       2.3.28, 2.3.28-doc -> 2.3.29, 2.3.29-doc
[U.]    ed                                  1.20 -> 1.20.1
[C.]    elfutils                            0.186, 0.190 -> 0.186, 0.190, 0.190-bin, 0.190-dev
[U.]    elm-bridge                          0.8.2, 0.8.2-doc -> 0.8.3, 0.8.3-doc
[U.]    file-embed                          0.0.15.0, 0.0.15.0-doc -> 0.0.16.0, 0.0.16.0-doc
[U.]    floskell                            0.10.8, 0.10.8-data, 0.10.8-doc -> 0.11.1, 0.11.1-data, 0.11.1-doc
[U.]    free                                5.1.10, 5.1.10-doc -> 5.2, 5.2-doc
[U.]    fuzzy                               0.1.0.1, 0.1.0.1-doc -> 0.1.1.0, 0.1.1.0-doc
[U*]    ghc                                 9.4.8, 9.4.8-doc, 9.4.8-with-packages -> 9.6.4, 9.6.4-doc, 9.6.4-with-packages
[C.]    ghc-check                           0.5.0.8 -> 0.5.0.8, 0.5.0.8-doc
[U.]    ghc-exactprint                      1.6.1.3, 1.6.1.3-doc -> 1.7.1.0, 1.7.1.0-doc
[U.]    ghc-lib-parser                      9.6.3.20231121, 9.6.3.20231121-data, 9.6.3.20231121-doc -> 9.6.4.20240109, 9.6.4.20240109-data, 9.6.4.20240109-doc
[U.]    ghc-trace-events                    0.1.2.7, 0.1.2.7-doc -> 0.1.2.8, 0.1.2.8-doc
[U*]    ghcide                              2.5.0.0, 2.5.0.0-doc -> 2.6.0.0, 2.6.0.0-doc
[U.]    hackage-security                    0.6.2.3, 0.6.2.3-doc -> 0.6.2.4, 0.6.2.4-doc
[U*]    haskell-language-server             2.5.0.0, 2.5.0.0-doc -> 2.6.0.0, 2.6.0.0-doc
[U.]    hie-bios                            0.12.1, 0.12.1-doc -> 0.13.1, 0.13.1-doc
[U.]    hiedb                               0.4.4.0, 0.4.4.0-doc -> 0.5.0.1, 0.5.0.1-doc
[U.]    hls-alternate-number-format-plugin  2.5.0.0, 2.5.0.0-doc -> 2.6.0.0, 2.6.0.0-doc
[U.]    hls-cabal-fmt-plugin                2.5.0.0, 2.5.0.0-doc -> 2.6.0.0, 2.6.0.0-doc
[U.]    hls-cabal-plugin                    2.5.0.0, 2.5.0.0-doc -> 2.6.0.0, 2.6.0.0-doc
[U.]    hls-call-hierarchy-plugin           2.5.0.0, 2.5.0.0-doc -> 2.6.0.0, 2.6.0.0-doc
[U.]    hls-change-type-signature-plugin    2.5.0.0, 2.5.0.0-doc -> 2.6.0.0, 2.6.0.0-doc
[U.]    hls-class-plugin                    2.5.0.0, 2.5.0.0-doc -> 2.6.0.0, 2.6.0.0-doc
[U.]    hls-code-range-plugin               2.5.0.0, 2.5.0.0-doc -> 2.6.0.0, 2.6.0.0-doc
[U.]    hls-eval-plugin                     2.5.0.0, 2.5.0.0-doc -> 2.6.0.0, 2.6.0.0-doc
[U.]    hls-explicit-fixity-plugin          2.5.0.0, 2.5.0.0-doc -> 2.6.0.0, 2.6.0.0-doc
[U.]    hls-explicit-imports-plugin         2.5.0.0, 2.5.0.0-doc -> 2.6.0.0, 2.6.0.0-doc
[U.]    hls-explicit-record-fields-plugin   2.5.0.0, 2.5.0.0-doc -> 2.6.0.0, 2.6.0.0-doc
[U.]    hls-floskell-plugin                 2.5.0.0, 2.5.0.0-doc -> 2.6.0.0, 2.6.0.0-doc
[U.]    hls-fourmolu-plugin                 2.5.0.0, 2.5.0.0-doc -> 2.6.0.0, 2.6.0.0-doc
[U.]    hls-gadt-plugin                     2.5.0.0, 2.5.0.0-doc -> 2.6.0.0, 2.6.0.0-doc
[U.]    hls-graph                           2.5.0.0, 2.5.0.0-data, 2.5.0.0-doc -> 2.6.0.0, 2.6.0.0-data, 2.6.0.0-doc
[U.]    hls-hlint-plugin                    2.5.0.0, 2.5.0.0-doc -> 2.6.0.0, 2.6.0.0-doc
[U.]    hls-module-name-plugin              2.5.0.0, 2.5.0.0-doc -> 2.6.0.0, 2.6.0.0-doc
[U.]    hls-ormolu-plugin                   2.5.0.0, 2.5.0.0-doc -> 2.6.0.0, 2.6.0.0-doc
[U.]    hls-overloaded-record-dot-plugin    2.5.0.0, 2.5.0.0-doc -> 2.6.0.0, 2.6.0.0-doc
[U.]    hls-plugin-api                      2.5.0.0, 2.5.0.0-doc -> 2.6.0.0, 2.6.0.0-doc
[U.]    hls-pragmas-plugin                  2.5.0.0, 2.5.0.0-doc -> 2.6.0.0, 2.6.0.0-doc
[U.]    hls-qualify-imported-names-plugin   2.5.0.0, 2.5.0.0-doc -> 2.6.0.0, 2.6.0.0-doc
[U.]    hls-refactor-plugin                 2.5.0.0, 2.5.0.0-doc -> 2.6.0.0, 2.6.0.0-doc
[U.]    hls-rename-plugin                   2.5.0.0, 2.5.0.0-doc -> 2.6.0.0, 2.6.0.0-doc
[U.]    hls-retrie-plugin                   2.5.0.0, 2.5.0.0-doc -> 2.6.0.0, 2.6.0.0-doc
[U.]    hls-splice-plugin                   2.5.0.0, 2.5.0.0-doc -> 2.6.0.0, 2.6.0.0-doc
[U.]    hls-stan-plugin                     2.5.0.0, 2.5.0.0-doc -> 2.6.0.0, 2.6.0.0-doc
[U.]    hls-stylish-haskell-plugin          2.5.0.0, 2.5.0.0-doc -> 2.6.0.0, 2.6.0.0-doc
[U.]    hscolour                            1.24.4, 1.24.4-data, 1.24.4-doc -> 1.25, 1.25-data, 1.25-doc
[U.]    http-client                         0.7.15, 0.7.15-doc -> 0.7.16, 0.7.16-doc
[U.]    http-client-tls                     0.3.6.1, 0.3.6.1-doc -> 0.3.6.3, 0.3.6.3-doc
[U.]    http-conduit                        2.3.8.1, 2.3.8.1-doc -> 2.3.8.3, 2.3.8.3-doc
[U.]    hwdata                              0.379 -> 0.380
[U.]    implicit-hie                        0.1.2.7, 0.1.2.7-doc -> 0.1.4.0, 0.1.4.0-doc
[C.]    libXcursor                          1.2.0, 1.2.1 -> 1.2.0, 1.2.2
[C.]    libassuan                           2.5.5, 2.5.6 -> 2.5.5, 2.5.7
[C.]    libcbor                             0.10.2, 0.8.0 -> 0.11.0, 0.8.0
[C.]    libffi                              3.4.2, 3.4.4, 3.4.4-dev -> 3.4.2, 3.4.6, 3.4.6-dev
[C.]    libgpg-error                        1.42, 1.47 -> 1.42, 1.48
[C.]    libmicrohttpd                       0.9.71 x2 -> 0.9.71, 0.9.77
[C.]    libpng-apng                         1.6.37, 1.6.40 -> 1.6.37, 1.6.43
[C.]    libsecret                           0.20.5, 0.21.3 -> 0.20.5, 0.21.4
[U.]    logict                              0.8.0.0, 0.8.0.0-doc -> 0.8.1.0, 0.8.1.0-doc
[U.]    lsp-types                           2.1.0.0 -> 2.1.1.0
[U.]    megaparsec                          9.3.1, 9.3.1-doc -> 9.5.0, 9.5.0-doc
[U.]    mesa                                24.0.1 -> 24.0.3
[U.]    monad-dijkstra                      0.1.1.4, 0.1.1.4-doc -> 0.1.1.5, 0.1.1.5-doc
[C.]    ncurses                             6.3, 6.4 -> 6.3, 6.4, 6.4-dev, 6.4-man
[C.]    nghttp2                             1.43.0-lib, 1.59.0-lib -> 1.43.0-lib, 1.60.0-lib
[U.]    nix                                 2.16.2, 2.16.2-man -> 2.16.3, 2.16.3-man
[C.]    npth                                1.6 x2 -> 1.6, 1.7
[U.]    optparse-applicative                0.17.1.0, 0.17.1.0-doc -> 0.18.1.0, 0.18.1.0-doc
[C.]    pcre2                               10.39, 10.42 -> 10.39, 10.43
[U.]    pcsclite                            2.0.1-lib -> 2.0.3-lib
[C.]    pixman                              0.38.4, 0.43.2 -> 0.38.4, 0.43.4
[U.]    primitive-unlifted                  0.1.3.1, 0.1.3.1-doc -> 2.1.0.0, 2.1.0.0-doc
[U.]    resourcet                           1.2.6, 1.2.6-doc -> 1.3.0, 1.3.0-doc
[U.]    retrie                              1.2.2, 1.2.2-doc -> 1.2.3, 1.2.3-doc
[U.]    s2n-tls                             1.4.3 -> 1.4.6
[U.]    safe                                0.3.19, 0.3.19-doc -> 0.3.21, 0.3.21-doc
[U.]    semigroupoids                       5.3.7, 5.3.7-doc -> 6.0.0.1, 6.0.0.1-doc
[U.]    some                                1.0.4.1, 1.0.4.1-doc -> 1.0.6, 1.0.6-doc
[U.]    sorted-list                         0.2.1.2, 0.2.1.2-doc -> 0.2.2.0, 0.2.2.0-doc
[U.]    split                               0.2.3.5, 0.2.3.5-doc -> 0.2.5, 0.2.5-doc
[U.]    sqlite-simple                       0.4.18.2, 0.4.18.2-doc -> 0.4.19.0, 0.4.19.0-doc
[U.]    stan                                0.1.1.0 -> 0.1.2.1
[U.]    tagged                              0.8.7, 0.8.7-doc -> 0.8.8, 0.8.8-doc
[U.]    th-abstraction                      0.4.5.0, 0.4.5.0-doc -> 0.5.0.0, 0.5.0.0-doc
[U.]    tls                                 1.6.0, 1.6.0-doc -> 1.8.0, 1.8.0-doc
[C.]    unbound                             1.14.0-lib, 1.19.1-lib -> 1.14.0-lib, 1.19.2-lib
[U.]    unordered-containers                0.2.19.1, 0.2.19.1-doc -> 0.2.20, 0.2.20-doc
[U.]    vector-stream                       0.1.0.0, 0.1.0.0-doc -> 0.1.0.1, 0.1.0.1-doc
[U*]    vscodium                            1.86.2.24057 -> 1.87.2.24072
[C.]    xz                                  5.2.5, 5.2.5-bin, 5.4.6, 5.4.6-bin -> 5.2.5, 5.2.5-bin, 5.6.1, 5.6.1-bin
Added packages:
[A.]    attoparsec-aeson                     2.1.0.0
[A.]    boring                               0.2.1, 0.2.1-doc
[A.]    crypton                              0.34, 0.34-doc
[A.]    crypton-connection                   0.3.1, 0.3.1-doc
[A.]    crypton-x509                         1.7.6, 1.7.6-doc
[A.]    crypton-x509-store                   1.6.9, 1.6.9-doc
[A.]    crypton-x509-system                  1.6.7, 1.6.7-doc
[A.]    crypton-x509-validation              1.6.12, 1.6.12-doc
[A.]    generic-arbitrary                    1.0.1, 1.0.1-doc
[A.]    hls-semantic-tokens-plugin           2.6.0.0, 2.6.0.0-doc
[A.]    libbacktrace                         0-unstable-2024-03-02
[A.]    old-time                             1.1.0.4, 1.1.0.4-doc
[A.]    prettyprinter-compat-ansi-wl-pprint  1.0.2, 1.0.2-doc
[A.]    quickcheck-instances                 0.3.30, 0.3.30-doc
[A.]    setup-debug-info-dirs-hook           <none>
[A.]    unix-time                            0.4.11, 0.4.11-doc
Removed packages:
[R.]    Cabal                     3.10.2.1, 3.10.2.1-doc
[R.]    Cabal-syntax              3.10.2.0, 3.10.2.0-doc
[R.]    connection                0.3.1, 0.3.1-doc
[R.]    cryptonite                0.30, 0.30-doc
[R.]    foldable1-classes-compat  0.1, 0.1-doc
[R.]    implicit-hie-cradle       0.5.0.1, 0.5.0.1-doc
[R.]    libbacktrace-unstable     2023-11-30
[R.]    x509                      1.7.7, 1.7.7-doc
[R.]    x509-store                1.6.9, 1.6.9-doc
[R.]    x509-system               1.6.7, 1.6.7-doc
[R.]    x509-validation           1.6.12, 1.6.12-doc
Closure size: 1163 -> 1176 (885 paths added, 872 paths removed, delta +13, disk usage -521.2MiB).