### PR TITLE
github workflows: drop use of magic nix cache

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -53,7 +53,6 @@ jobs:
       - uses: cachix/install-nix-action@v18
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: DeterminateSystems/magic-nix-cache-action@main
       - name: Download elbum closure artifact
         uses: dawidd6/action-download-artifact@v6
         with:

--- a/.github/workflows/niv-update.yml
+++ b/.github/workflows/niv-update.yml
@@ -23,7 +23,6 @@ jobs:
     - uses: cachix/install-nix-action@v18
       with:
         nix_path: nixpkgs=channel:nixos-unstable
-    - uses: DeterminateSystems/magic-nix-cache-action@main
     - run: |
         nix-build --max-jobs 1 -o old
         nix-build --max-jobs 1 shell.nix -A inputDerivation -o shell-old

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -15,7 +15,6 @@ jobs:
       - uses: cachix/install-nix-action@v18
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: DeterminateSystems/magic-nix-cache-action@main
       - run: |
           nix-build
           nix-store --export $(nix-store --query --requisites result) > elbum.nar
@@ -36,5 +35,4 @@ jobs:
       - uses: cachix/install-nix-action@v18
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: DeterminateSystems/magic-nix-cache-action@main
       - run: nix-shell --run true

--- a/.github/workflows/nix-format-check.yml
+++ b/.github/workflows/nix-format-check.yml
@@ -13,5 +13,4 @@ jobs:
       - uses: cachix/install-nix-action@v18
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - uses: DeterminateSystems/magic-nix-cache-action@main
       - run: ./nix/format-check


### PR DESCRIPTION
github API it relied upon has been retired