### PR TITLE
switch to the actually-correct nixfmt package

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,16 +1,24 @@
-{ sources ? import nix/sources.nix, }:
+{
+  sources ? import nix/sources.nix,
+}:
 
-let nixpkgs = import sources.nixpkgs { };
-in with nixpkgs;
+let
+  nixpkgs = import sources.nixpkgs { };
+in
+with nixpkgs;
 
 let
   client = import src/client/default.nix { inherit nixpkgs; };
   generator = import src/generator/default.nix { inherit nixpkgs; };
 
-in stdenv.mkDerivation {
+in
+stdenv.mkDerivation {
   name = "elbum";
   src = ./src/elbum;
-  buildInputs = [ client generator ];
+  buildInputs = [
+    client
+    generator
+  ];
   installPhase = ''
     mkdir -p $out/bin;
     cp -v elbum $out/bin

--- a/nix/niv-shell.nix
+++ b/nix/niv-shell.nix
@@ -1,8 +1,16 @@
-{ sources ? import ./sources.nix, }:
+{
+  sources ? import ./sources.nix,
+}:
 
-let nixpkgs = import sources.nixpkgs { };
+let
+  nixpkgs = import sources.nixpkgs { };
 
-in nixpkgs.pkgs.stdenv.mkDerivation {
+in
+nixpkgs.pkgs.stdenv.mkDerivation {
   name = "niv-env-0";
-  buildInputs = with nixpkgs.pkgs; [ niv nix nvd ];
+  buildInputs = with nixpkgs.pkgs; [
+    niv
+    nix
+    nvd
+  ];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,12 +1,16 @@
-{ sources ? import nix/sources.nix, }:
+{
+  sources ? import nix/sources.nix,
+}:
 
-let nixpkgs = import sources.nixpkgs { };
+let
+  nixpkgs = import sources.nixpkgs { };
 
-in let
+in
+let
   inherit (nixpkgs) pkgs;
   haskellPkgs = pkgs.haskellPackages;
-  ghc = haskellPkgs.ghcWithPackages (ps:
-    with ps; [
+  ghc = haskellPkgs.ghcWithPackages (
+    ps: with ps; [
       async
       elm-bridge
       extra
@@ -17,22 +21,25 @@ in let
       safe
       tasty
       tasty-golden
-    ]);
+    ]
+  );
 
   # pinned to recent (but cached) ancestor of
   # dadc08be jetbrains.idea-{community,ultimate}: 2021.3.2 → 2022.1
   olderIdea = (import sources.olderIdeaNixpkgs { }).jetbrains.idea-community;
 
   elmPlugin = pkgs.fetchurl {
-    url =
-      "https://github.com/utiliteez/intellij-elm/releases/download/v5.0.0-beta21/Elm.IntelliJ-5.0.0-beta21.zip";
+    url = "https://github.com/utiliteez/intellij-elm/releases/download/v5.0.0-beta21/Elm.IntelliJ-5.0.0-beta21.zip";
     hash = "sha256-JkYNZG/H4BMxJDBxlZ14BB7I92qqDo2zcbd90/kILIg=";
   };
 
-in pkgs.stdenv.mkDerivation {
+in
+pkgs.stdenv.mkDerivation {
   name = "elbum-haskell-env-0";
-  buildInputs = with pkgs;
-    with haskellPkgs; [
+  buildInputs =
+    with pkgs;
+    with haskellPkgs;
+    [
       # basic tooling
       pkgs.git # disambiguates from haskellPackages.git
 
@@ -59,10 +66,9 @@ in pkgs.stdenv.mkDerivation {
 
       # nix
       niv
-      nixfmt
+      pkgs.nixfmt # there is an older one in haskellPackages, avoid it
       nixd
     ];
 
-  shellHook =
-    "echo elm plugin: ${elmPlugin}; eval $(egrep ^export ${ghc}/bin/ghc)";
+  shellHook = "echo elm plugin: ${elmPlugin}; eval $(egrep ^export ${ghc}/bin/ghc)";
 }

--- a/src/client/album-types-gen.nix
+++ b/src/client/album-types-gen.nix
@@ -1,15 +1,22 @@
 # to produce Album.elm, run:
 #nix-build -o Album.elm.dir album-types-gen.nix
 
-{ nixpkgs ? import <nixpkgs> { }, }:
+{
+  nixpkgs ? import <nixpkgs> { },
+}:
 
 with nixpkgs;
 
 let
-  ghc =
-    pkgs.haskellPackages.ghcWithPackages (ps: with ps; [ elm-bridge parallel ]);
+  ghc = pkgs.haskellPackages.ghcWithPackages (
+    ps: with ps; [
+      elm-bridge
+      parallel
+    ]
+  );
 
-in stdenv.mkDerivation {
+in
+stdenv.mkDerivation {
   name = "Album.elm";
   src = ../generator/AlbumTypes.hs;
   gen = ./album-types-gen.hs;

--- a/src/client/default.nix
+++ b/src/client/default.nix
@@ -1,4 +1,7 @@
-{ config ? { }, nixpkgs ? import <nixpkgs> config, }:
+{
+  config ? { },
+  nixpkgs ? import <nixpkgs> config,
+}:
 
 with nixpkgs;
 
@@ -11,7 +14,13 @@ let
   nodejs = nodejs_24;
 
   mkDerivation =
-    { srcs ? ./nix/elm-srcs.nix, src, name, srcdir ? "./src", targets ? [ ], }:
+    {
+      srcs ? ./nix/elm-srcs.nix,
+      src,
+      name,
+      srcdir ? "./src",
+      targets ? [ ],
+    }:
     stdenv.mkDerivation rec {
       inherit name src;
 
@@ -20,27 +29,33 @@ let
         inherit nodejs;
       };
 
-      buildInputs =
-        [ elmPackages.elm importNpmLock.hooks.linkNodeModulesHook nodejs ];
+      buildInputs = [
+        elmPackages.elm
+        importNpmLock.hooks.linkNodeModulesHook
+        nodejs
+      ];
 
-      postUnpack = (elmPackages.fetchElmDeps {
-        elmVersion = "0.19.1";
-        elmPackages = import ./nix/elm-srcs.nix;
-        registryDat = ./nix/registry.dat;
-      });
+      postUnpack = (
+        elmPackages.fetchElmDeps {
+          elmVersion = "0.19.1";
+          elmPackages = import ./nix/elm-srcs.nix;
+          registryDat = ./nix/registry.dat;
+        }
+      );
 
-      buildPhase = let
-        elmfile = module:
-          "${srcdir}/${builtins.replaceStrings [ "." ] [ "/" ] module}.elm";
-      in ''
-        mkdir -p $out/share/doc
-        cp -iv ${albumTypes}/Album.elm src;
-        ${lib.concatStrings (map (module: ''
-          elm make ${
-            elmfile module
-          } --output $out/${module}.js --docs $out/share/doc/${module}.json --optimize
-        '') targets)}
-      '';
+      buildPhase =
+        let
+          elmfile = module: "${srcdir}/${builtins.replaceStrings [ "." ] [ "/" ] module}.elm";
+        in
+        ''
+          mkdir -p $out/share/doc
+          cp -iv ${albumTypes}/Album.elm src;
+          ${lib.concatStrings (
+            map (module: ''
+              elm make ${elmfile module} --output $out/${module}.js --docs $out/share/doc/${module}.json --optimize
+            '') targets
+          )}
+        '';
 
       installPhase = ''
         mv -iv $out/src/Main.js $out/elbum.js;
@@ -64,25 +79,38 @@ let
         ./node_modules/.bin/elm-test --seed 20221126
       '';
     };
-in mkDerivation {
+in
+mkDerivation {
   name = "jerith666-elbum-0.1.0";
   srcs = ./elm-srcs.nix;
   src = lib.cleanSourceWith {
     src = ./.;
-    filter = path: type:
-      (type == "regular" && (pkgs.lib.hasSuffix ".elm" path
-        || pkgs.lib.hasSuffix "elm.json" path
-        || pkgs.lib.hasSuffix "index.html" path
-        || pkgs.lib.hasSuffix "package.json" path
-        || pkgs.lib.hasSuffix "package-lock.json" path
-        || pkgs.lib.hasSuffix ".htaccess" path)) || (type == "directory"
-          && (pkgs.lib.hasSuffix "vendor" path
-            || pkgs.lib.hasSuffix "elm-route-url" path
-            || pkgs.lib.hasSuffix "touch-events" path
-            || pkgs.lib.hasSuffix "src" path || pkgs.lib.hasSuffix "tests" path
-            || pkgs.lib.hasSuffix "review" path
-            || pkgs.lib.hasSuffix "Sandbox" path
-            || pkgs.lib.hasSuffix "Utils" path));
+    filter =
+      path: type:
+      (
+        type == "regular"
+        && (
+          pkgs.lib.hasSuffix ".elm" path
+          || pkgs.lib.hasSuffix "elm.json" path
+          || pkgs.lib.hasSuffix "index.html" path
+          || pkgs.lib.hasSuffix "package.json" path
+          || pkgs.lib.hasSuffix "package-lock.json" path
+          || pkgs.lib.hasSuffix ".htaccess" path
+        )
+      )
+      || (
+        type == "directory"
+        && (
+          pkgs.lib.hasSuffix "vendor" path
+          || pkgs.lib.hasSuffix "elm-route-url" path
+          || pkgs.lib.hasSuffix "touch-events" path
+          || pkgs.lib.hasSuffix "src" path
+          || pkgs.lib.hasSuffix "tests" path
+          || pkgs.lib.hasSuffix "review" path
+          || pkgs.lib.hasSuffix "Sandbox" path
+          || pkgs.lib.hasSuffix "Utils" path
+        )
+      );
   };
   srcdir = ".";
   targets = [ "src/Main" ];

--- a/src/generator/default.nix
+++ b/src/generator/default.nix
@@ -1,2 +1,4 @@
-{ nixpkgs ? import <nixpkgs> { }, }:
+{
+  nixpkgs ? import <nixpkgs> { },
+}:
 nixpkgs.pkgs.haskellPackages.callPackage ./gen-album.nix { }

--- a/src/generator/gen-album.nix
+++ b/src/generator/gen-album.nix
@@ -1,5 +1,20 @@
-{ mkDerivation, lib, aeson, async, base, bytestring, elm-bridge, extra, filepath
-, JuicyPixels, parallel, parallel-io, regex-compat, safe, tasty, tasty-golden,
+{
+  mkDerivation,
+  lib,
+  aeson,
+  async,
+  base,
+  bytestring,
+  elm-bridge,
+  extra,
+  filepath,
+  JuicyPixels,
+  parallel,
+  parallel-io,
+  regex-compat,
+  safe,
+  tasty,
+  tasty-golden,
 }:
 mkDerivation {
   pname = "elbum";


### PR DESCRIPTION
the parent commit picked up haskellPackages.nixfmt, not pkgs.nixfmt. the former is older and imposed deprecated formatting on us.  this correct version puts everything except a few very trivial things back the way they were.